### PR TITLE
chore(ci): start implementing caching (refs #5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,35 +7,71 @@ on:
       - development
 
 jobs:
-  jest-tests:
-    name: Jest CI Tests
+  # Install dependencies once and cache them
+  install-deps:
+    name: Install Service Dependencies
     runs-on: ubuntu-latest
+    outputs:
+      cache-hit: ${{ steps.cache-deps.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
+      - name: Cache node modules
+        id: cache-deps
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - run: npm install
+
+  jest-tests:
+    name: Jest CI Tests
+    runs-on: ubuntu-latest
+    needs: install-deps
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Restore npm cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
       - run: npm run test:ci
 
   prettier-check:
     name: Prettier Check
     runs-on: ubuntu-latest
+    needs: install-deps
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
-      - run: npm install
+      - name: Restore npm cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
       - run: npm run format:check
 
   eslint-check:
     name: ESLint Check
     runs-on: ubuntu-latest
+    needs: install-deps
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
-      - run: npm install
+      - name: Restore npm cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
       - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,8 @@ on:
       - development
 
 jobs:
-  # Install dependencies once and cache them
   install-deps:
-    name: Install Service Dependencies
+    name: Install & Cache Dependencies
     runs-on: ubuntu-latest
     outputs:
       cache-hit: ${{ steps.cache-deps.outputs.cache-hit }}
@@ -18,15 +17,15 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
-      - name: Cache node modules
+      - name: Cache npm
         id: cache-deps
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: npm install
+      - run: npm ci
 
   jest-tests:
     name: Jest CI Tests
@@ -41,7 +40,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
       - run: npm run test:ci
 
   prettier-check:
@@ -57,7 +59,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
       - run: npm run format:check
 
   eslint-check:
@@ -73,5 +78,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
### This PR enhances the GitHub Actions CI workflow by introducing dependency caching.  

#### Changes introduced:
- Added `actions/cache` to reuse npm cache between workflow runs.
- Cache key is based on `package-lock.json` hash to ensure cache invalidation when dependencies change.
- Reduced redundant dependency downloads and improved build times.

#### Why:
- Faster CI runs
- Less bandwidth usage
- Smoother developer experience

#### Linked Issue:
Attempts to close #5
