### PR TITLE
chore(ci): remove redundant Node.js setup and npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: CI
-
 on:
   pull_request:
     branches:
@@ -7,79 +6,85 @@ on:
       - development
 
 jobs:
-  install-deps:
-    name: Install & Cache Dependencies
+  setup:
+    name: Setup Dependencies
     runs-on: ubuntu-latest
-    outputs:
-      cache-hit: ${{ steps.cache-deps.outputs.cache-hit }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      - name: Cache npm
+          cache: 'npm'
+      
+      # Cache node_modules to share across all jobs
+      - name: Cache node modules
         id: cache-deps
         uses: actions/cache@v3
         with:
-          path: ~/.npm
+          path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - run: npm ci
+      
+      - name: Install dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: npm ci
 
   jest-tests:
     name: Jest CI Tests
     runs-on: ubuntu-latest
-    needs: install-deps
+    needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      - name: Restore npm cache
+      
+      # Restore cached node_modules
+      - name: Restore node modules
         uses: actions/cache@v3
         with:
-          path: ~/.npm
+          path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - run: npm ci
+      
       - run: npm run test:ci
 
   prettier-check:
     name: Prettier Check
     runs-on: ubuntu-latest
-    needs: install-deps
+    needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      - name: Restore npm cache
+      
+      # Restore cached node_modules
+      - name: Restore node modules
         uses: actions/cache@v3
         with:
-          path: ~/.npm
+          path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - run: npm ci
+      
       - run: npm run format:check
 
   eslint-check:
     name: ESLint Check
     runs-on: ubuntu-latest
-    needs: install-deps
+    needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      - name: Restore npm cache
+      
+      # Restore cached node_modules
+      - name: Restore node modules
         uses: actions/cache@v3
         with:
-          path: ~/.npm
+          path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - run: npm ci
+      
       - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'
-      
+
       # Cache node_modules to share across all jobs
       - name: Cache node modules
         id: cache-deps
@@ -24,7 +24,7 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      
+
       - name: Install dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: npm ci
@@ -35,18 +35,18 @@ jobs:
     needs: setup
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      
+
       # Restore cached node_modules
       - name: Restore node modules
         uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      
+
       - run: npm run test:ci
 
   prettier-check:
@@ -55,18 +55,18 @@ jobs:
     needs: setup
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      
+
       # Restore cached node_modules
       - name: Restore node modules
         uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      
+
       - run: npm run format:check
 
   eslint-check:
@@ -75,16 +75,16 @@ jobs:
     needs: setup
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      
+
       # Restore cached node_modules
       - name: Restore node modules
         uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      
+
       - run: npm run lint


### PR DESCRIPTION
### This PR addresses **issue #10** and refactors the GitHub Actions workflow to eliminate the repeated Node.js setup and `npm install` across multiple jobs. By centralizing the setup and leveraging caching/artifacts, we:

* Reduce total CI runtime
* Save compute resources
* Maintain isolated, reliable jobs
* Keep the workflow more maintainable and efficient

#### Changes:

* Added a shared setup step for Node.js and dependencies
* Implemented caching of `node_modules` or relevant package manager cache
* Updated jobs to reuse setup instead of reinstalling

#### Benefits:

* Faster builds
* Less redundant work
* Easier to extend CI in the future

#### Linked Issue:

* Resolves #10 